### PR TITLE
Fix OG preview instructions

### DIFF
--- a/public/images/og-preview-instructions.md
+++ b/public/images/og-preview-instructions.md
@@ -32,4 +32,4 @@ After creating and uploading the image, test with:
 - LinkedIn Post Inspector: https://www.linkedin.com/post-inspector/
 - Twitter Card Validator: https://cards-dev.twitter.com/validator
 
-Place the final image at: `/public/images/og-preview.png`
+Place the final image at: /public/images/og-preview.png


### PR DESCRIPTION
## Summary
- update OG preview instructions text to remove trailing shell prompt

## Testing
- `cat -A public/images/og-preview-instructions.md | tail -n 4`

------
https://chatgpt.com/codex/tasks/task_e_684a8129fb4883328c3551d90daa016c