### PR TITLE
Fix progressive tax band calculation

### DIFF
--- a/src/utils/taxCalculator.ts
+++ b/src/utils/taxCalculator.ts
@@ -22,7 +22,7 @@ function calculateProgressiveTax(annualIncome: number): number {
   
   for (const band of TAX_BANDS) {
     if (annualIncome > band.min - 1) {
-      const taxableInThisBand = Math.min(annualIncome, band.max) - band.min + 1
+      const taxableInThisBand = Math.min(annualIncome, band.max) - band.min
       tax += taxableInThisBand * band.rate
     }
   }


### PR DESCRIPTION
## Summary
- remove off-by-one when computing tax per band

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a81ff46608332a2c4c407281eee3b